### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a **zero-dependency static website** (ABCspareparts landing page) deployed via GitHub Pages (Jekyll). There is nothing to compile or bundle for the app itself.
+
+### Services / how to run
+- There is a single "service": the static site. Serve the repo root with any static file server, e.g. `python3 -m http.server 8000`, then open `http://localhost:8000/index.html`.
+- Node.js (v22) is preinstalled and is only needed to run the build/generator scripts, not to serve the site.
+
+### Build / generate (Node scripts, see `package.json`)
+- `npm run build:brands` — regenerates the ~11,960 `marche/*.html` brand pages from the `brands` array embedded in `index.html` (runs `extract-brands.js` then `generate-brand-pages.js`). This rewrites thousands of files, so only run when intentionally regenerating.
+- `npm run build:casi` — regenerates the success-case pages under `casi-di-successo/` from `supply-cases.json`.
+- These generators are the closest thing to a "dev/build" step; there is no watch/hot-reload. After editing source data, re-run the relevant generator and reload the page.
+
+### Lint / test / verify
+- There is no linter or unit test framework. `npm run verify` (`verify-build.js`) is the check to run: it validates brand page counts, sitemap `<loc>` counts, required SEO markers (canonical, hreflang, related-brands block), and case-page consistency. Run it after any change to `index.html` brands, generators, or sitemaps.
+
+### Gotchas
+- `verify-build.js` hardcodes expectations (e.g. the `11960+` marker in `index.html` and exact page counts), so it will fail if brand/case data changes without re-running the generators.
+- Brand pages live in `marche/` and must reference site-root pages with `../` (e.g. `href="../index.html"`); `verify-build.js` enforces this.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for this zero-dependency static site (ABCspareparts landing page, GitHub Pages / Jekyll).

No application code was modified. Adds `AGENTS.md` with durable, non-obvious instructions for future agents:
- How to run the site locally (`python3 -m http.server 8000`)
- Node build/generator scripts (`npm run build:brands`, `npm run build:casi`)
- The `npm run verify` check and its hardcoded expectations
- `marche/` relative-path gotcha

## Environment verification

- `npm run verify` → passes (11960 brands, 11960 HTML pages, 11960 sitemap URLs + SEO checks)
- Served the site and confirmed `index.html`, `marche.html`, `marche/siemens.html`, `casi-di-successo.html` return HTTP 200
- Browser hello-world test: loaded homepage, switched language EN → IT (text updated dynamically), navigated to brands listing and a Siemens brand page

[abcspareparts_dev_env_demo.mp4](https://cursor.com/agents/bc-f1f936ec-803a-4421-b353-d59577e58c25/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fabcspareparts_dev_env_demo.mp4)
[Homepage in Italian after language switch](https://cursor.com/agents/bc-f1f936ec-803a-4421-b353-d59577e58c25/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_italian.webp)
[Siemens brand page](https://cursor.com/agents/bc-f1f936ec-803a-4421-b353-d59577e58c25/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsiemens_brand_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1f936ec-803a-4421-b353-d59577e58c25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1f936ec-803a-4421-b353-d59577e58c25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

