### PR TITLE
Step 1/2: infrastruttura ricerca listini grandi (--only rebuild)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+listini/*.xlsx
+listini/*.xls
+!listini/README.md

--- a/build-brand-parts.js
+++ b/build-brand-parts.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const { slugify } = require('./brand-slug.js');
-const { loadListiniParts } = require('./import-listino.js');
+const { loadListiniParts, writeListinoDataFile, INLINE_LISTINO_MAX } = require('./import-listino.js');
 
 const ROOT = __dirname;
 const BASE = 'https://abcspareparts.eu';
@@ -193,7 +193,19 @@ function supplementFromListini(rowsBySlug, brandSlugs, caseMap, listiniBySlug) {
     }
     const row = rowsBySlug.get(brand_slug);
     row.brand = brand;
-    row.parts = mergePartLists([...row.parts, ...parts]);
+
+    if (parts.length > INLINE_LISTINO_MAX) {
+      const meta = writeListinoDataFile(brand_slug, brand, parts);
+      row.listino = {
+        file: meta.file,
+        count: meta.count,
+        preview: meta.preview
+      };
+      // Keep existing ERP/case parts inline; do not dump 100k+ codes into HTML.
+      console.log(`listino ${brand_slug}: ${meta.count} codes → ${meta.file} (search UI, no prices)`);
+    } else {
+      row.parts = mergePartLists([...row.parts, ...parts]);
+    }
   }
 }
 
@@ -272,7 +284,12 @@ function buildBrandRows() {
   };
 }
 
-function formatPartPreview(parts, limit = 4) {
+function formatPartPreview(row, limit = 4) {
+  if (row.listino?.count) {
+    const preview = (row.listino.preview || []).slice(0, limit).join(', ');
+    return `${preview} (+${row.listino.count} listino codes, search on page)`;
+  }
+  const parts = row.parts || [];
   const shown = parts.slice(0, limit).map((p) => p.part_number);
   const extra = parts.length > limit ? ` (+${parts.length - limit} more)` : '';
   return `${shown.join(', ')}${extra}`;
@@ -294,7 +311,8 @@ function writeSitemapBrandParts(brands) {
   const langs = ['it', 'de', 'en', 'es', 'fr'];
   let body = '';
   for (const row of brands) {
-    if (!row.brand_slug || !row.parts?.length) continue;
+    if (!row.brand_slug) continue;
+    if (!row.parts?.length && !row.listino?.count) continue;
     const loc = `${BASE}/marche/${row.brand_slug}.html`;
     body += '  <url>\n';
     body += `    <loc>${loc}</loc>\n`;
@@ -324,7 +342,7 @@ function writeSitemapPartCodes(brands) {
   let urlCount = 0;
   for (const row of brands) {
     if (!row.brand_slug || !row.parts?.length) continue;
-    const pageLoc = `${BASE}/marche/${row.brand_slug}.html`;
+    // Large listino catalogs use search UI — do not explode sitemap with 100k+ URLs.
     for (const part of row.parts) {
       const loc = partPageUrl(row.brand_slug, part.part_number);
       body += '  <url>\n';
@@ -355,11 +373,11 @@ ${body}</urlset>
 function updateLlmsTxt(brands) {
   const llmsPath = path.join(ROOT, 'llms.txt');
   let content = fs.readFileSync(llmsPath, 'utf8');
-  const partCount = brands.reduce((sum, row) => sum + row.parts.length, 0);
-  const intro = `## Brand pages with quotable part numbers\n\n${brands.length} manufacturer pages list specific part numbers from quotations, orders, or price lists — each code is clickable for a no-obligation enquiry (DE/EN/IT/ES/FR via \`?lang=\`). Total: ${partCount} part references.\n`;
+  const partCount = brands.reduce((sum, row) => sum + (row.parts?.length || 0) + (row.listino?.count || 0), 0);
+  const intro = `## Brand pages with quotable part numbers\n\n${brands.length} manufacturer pages list specific part numbers from quotations, orders, or price lists — each code is clickable for a no-obligation enquiry (DE/EN/IT/ES/FR via \`?lang=\`). No list prices are published. Total: ${partCount} part references.\n`;
   const lines = brands.map((row) => {
     const url = `${BASE}/marche/${row.brand_slug}.html`;
-    const preview = formatPartPreview(row.parts);
+    const preview = formatPartPreview(row);
     return `- [${row.brand}](${url}): ${preview}`;
   });
   const section = `${intro}\n${lines.join('\n')}\n`;
@@ -372,8 +390,13 @@ function updateLlmsTxt(brands) {
 
   const catalogLines = [];
   for (const row of brands) {
-    if (!row.brand_slug || !row.parts?.length) continue;
-    for (const part of row.parts) {
+    if (!row.brand_slug) continue;
+    if (row.listino?.count) {
+      catalogLines.push(
+        `- [${row.brand} listino](${BASE}/marche/${row.brand_slug}.html) — ${row.listino.count} codes searchable on page (no prices); data: ${BASE}/${row.listino.file}`
+      );
+    }
+    for (const part of row.parts || []) {
       const url = partPageUrl(row.brand_slug, part.part_number);
       const desc = part.description && part.description !== part.part_number
         ? ` — ${part.description}`
@@ -381,7 +404,7 @@ function updateLlmsTxt(brands) {
       catalogLines.push(`- [${row.brand} ${part.part_number}](${url})${desc}`);
     }
   }
-  const catalogSection = `## Full part number catalog\n\n${partCount} quotable part references with direct enquiry links (\`?part=\` on brand pages):\n\n${catalogLines.join('\n')}\n`;
+  const catalogSection = `## Full part number catalog\n\nQuotable part references with direct enquiry links (\`?part=\` on brand pages). Large manufacturer listini use on-page search (codes only, no prices):\n\n${catalogLines.join('\n')}\n`;
 
   if (/## Full part number catalog/.test(content)) {
     content = content.replace(/## Full part number catalog[\s\S]*?(?=\n## )/, catalogSection.trimEnd());
@@ -389,7 +412,8 @@ function updateLlmsTxt(brands) {
     content = content.replace(/\n## Success story pages/, `\n${catalogSection}\n## Success story pages`);
   }
 
-  const sitemapSection = `## XML sitemaps (search engines)\n\n- [Sitemap index](${BASE}/sitemap-index.xml)\n- [Brand pages with parts](${BASE}/sitemap-brand-parts.xml) — ${brands.length} high-priority brand URLs\n- [Individual part codes](${BASE}/sitemap-part-codes.xml) — ${partCount} part-specific URLs\n- [All brand pages](${BASE}/sitemap-brands.xml)\n- [Success stories](${BASE}/sitemap-cases.xml)\n`;
+  const brandPartsCount = brands.filter((r) => (r.parts?.length || 0) + (r.listino?.count || 0) > 0).length;
+  const sitemapSection = `## XML sitemaps (search engines)\n\n- [Sitemap index](${BASE}/sitemap-index.xml)\n- [Brand pages with parts](${BASE}/sitemap-brand-parts.xml) — ${brandPartsCount} high-priority brand URLs\n- [Individual part codes](${BASE}/sitemap-part-codes.xml) — inline ERP/case part URLs (large listini use brand-page search)\n- [All brand pages](${BASE}/sitemap-brands.xml)\n- [Success stories](${BASE}/sitemap-cases.xml)\n`;
 
   if (/## XML sitemaps \(search engines\)/.test(content)) {
     content = content.replace(/## XML sitemaps \(search engines\)[\s\S]*?(?=\n## |$)/, sitemapSection.trimEnd());
@@ -402,19 +426,22 @@ function updateLlmsTxt(brands) {
 
 function main() {
   const output = buildBrandRows();
+  // Drop empty brands (no inline parts and no listino)
+  output.brands = output.brands.filter((r) => (r.parts && r.parts.length) || r.listino?.count);
   const outPath = path.join(ROOT, 'brand-order-parts.json');
   fs.writeFileSync(outPath, `${JSON.stringify(output, null, 2)}\n`, 'utf8');
   writeSitemapBrandParts(output.brands);
   const partUrlCount = writeSitemapPartCodes(output.brands);
   updateLlmsTxt(output.brands);
 
-  const partCount = output.brands.reduce((sum, row) => sum + row.parts.length, 0);
+  const partCount = output.brands.reduce((sum, row) => sum + (row.parts?.length || 0) + (row.listino?.count || 0), 0);
   console.log('brand-order-parts.json:', output.brands.length, 'brands,', partCount, 'parts');
   console.log('sitemap-brand-parts.xml:', output.brands.length, 'URLs');
   console.log('sitemap-part-codes.xml:', partUrlCount, 'URLs');
   console.log('llms.txt: brand parts + full catalog + sitemaps updated');
   for (const row of output.brands) {
-    console.log(`  ${row.brand} (${row.brand_slug}): ${row.parts.length}`);
+    const extra = row.listino?.count ? ` + listino ${row.listino.count}` : '';
+    console.log(`  ${row.brand} (${row.brand_slug}): ${(row.parts || []).length}${extra}`);
   }
 }
 

--- a/generate-brand-pages.js
+++ b/generate-brand-pages.js
@@ -34,8 +34,12 @@ function loadPartsBySlug() {
     const data = JSON.parse(fs.readFileSync(p, 'utf8'));
     const map = new Map();
     for (const row of data.brands || []) {
-      if (!row.brand_slug || !row.parts?.length) continue;
-      map.set(row.brand_slug, row.parts);
+      if (!row.brand_slug) continue;
+      if (!row.parts?.length && !row.listino?.count) continue;
+      map.set(row.brand_slug, {
+        parts: row.parts || [],
+        listino: row.listino || null
+      });
     }
     console.log('brand-order-parts.json: brands with parts', map.size);
     return map;
@@ -139,8 +143,11 @@ function buildTranslations(brand) {
       brand_parts_title: 'Diese Teilenummern anfragen',
       brand_parts_intro: 'Codes zur Anfrage (aus Angeboten, Lieferungen oder Herstellerlisten). Keine Preise auf der Seite — klicken Sie auf einen Code, um das vorausgefüllte Formular zu öffnen.',
       brand_parts_search: 'Teilenummer suchen…',
+      brand_parts_search_hint: 'Mindestens 3 Zeichen eingeben, dann auf einen Code klicken, um anzufragen.',
+      brand_parts_listino_intro: 'Herstellerliste: suchen Sie eine Teilenummer und fordern Sie ein unverbindliches Angebot an. Es werden keine Preise angezeigt.',
       brand_parts_count: 'codes',
       brand_parts_empty: 'Keine Treffer',
+      brand_parts_type_more: 'Bitte mindestens 3 Zeichen eingeben…',
       brand_parts_case: 'Erfolgsgeschichte',
       brand_parts_quote: 'Angebot anfragen',
       quote_modal_title: 'Unverbindliche Anfrage',
@@ -183,8 +190,11 @@ function buildTranslations(brand) {
       brand_parts_title: 'Request these part numbers',
       brand_parts_intro: 'Codes available to request (from quotations, deliveries, or price lists). No prices on this page — click a code to open the pre-filled enquiry form.',
       brand_parts_search: 'Search part number…',
+      brand_parts_search_hint: 'Type at least 3 characters, then click a code to request a quote.',
+      brand_parts_listino_intro: 'Manufacturer list: search a part number and request a no-obligation quote. No prices are shown.',
       brand_parts_count: 'codes',
       brand_parts_empty: 'No matches',
+      brand_parts_type_more: 'Please type at least 3 characters…',
       brand_parts_case: 'Success story',
       brand_parts_quote: 'Request quote',
       quote_modal_title: 'No-obligation enquiry',
@@ -227,8 +237,11 @@ function buildTranslations(brand) {
       brand_parts_title: 'Richiedi questi codici articolo',
       brand_parts_intro: 'Codici disponibili per richiesta (da preventivi, forniture o listini). Nessun prezzo in pagina: clicchi su un codice per aprire il modulo già compilato.',
       brand_parts_search: 'Cerca codice articolo…',
+      brand_parts_search_hint: 'Digiti almeno 3 caratteri, poi clicchi su un codice per richiederlo.',
+      brand_parts_listino_intro: 'Listino costruttore: cerchi un codice e richieda un preventivo senza impegno. I prezzi non sono mostrati.',
       brand_parts_count: 'codici',
       brand_parts_empty: 'Nessun risultato',
+      brand_parts_type_more: 'Digiti almeno 3 caratteri…',
       brand_parts_case: 'Caso di successo',
       brand_parts_quote: 'Richiedi preventivo',
       quote_modal_title: 'Richiesta senza impegno',
@@ -269,10 +282,13 @@ function buildTranslations(brand) {
       contact_iframe_title: `Formulario – recambios ${H}`,
       contact_legal_note: 'Datos legales completos en el <a href="../impressum.html" target="_blank" rel="noopener">Aviso legal</a>.',
       brand_parts_title: 'Solicitar estas referencias',
-      brand_parts_intro: 'Códigos de presupuestos, suministros o nuestras listas de precios del fabricante. Haga clic en un código para abrir el formulario precargado (descripción opcional).',
+      brand_parts_intro: 'Códigos disponibles para solicitud (presupuestos, suministros o listas). Sin precios en la página: haga clic en un código para abrir el formulario precargado.',
       brand_parts_search: 'Buscar referencia…',
+      brand_parts_search_hint: 'Escriba al menos 3 caracteres y haga clic en un código para solicitarlo.',
+      brand_parts_listino_intro: 'Lista del fabricante: busque una referencia y solicite presupuesto sin compromiso. No se muestran precios.',
       brand_parts_count: 'códigos',
       brand_parts_empty: 'Sin resultados',
+      brand_parts_type_more: 'Escriba al menos 3 caracteres…',
       brand_parts_case: 'Caso de éxito',
       brand_parts_quote: 'Solicitar presupuesto',
       quote_modal_title: 'Solicitud sin compromiso',
@@ -313,10 +329,13 @@ function buildTranslations(brand) {
       contact_iframe_title: `Formulaire – pièces ${H}`,
       contact_legal_note: 'Informations légales complètes dans les <a href="../impressum.html" target="_blank" rel="noopener">mentions légales</a>.',
       brand_parts_title: 'Demander ces références',
-      brand_parts_intro: 'Codes issus de devis, livraisons ou de nos listes tarifaires constructeur. Cliquez sur un code pour ouvrir le formulaire prérempli (description optionnelle).',
+      brand_parts_intro: 'Codes disponibles pour demande (devis, livraisons ou listes). Aucun prix sur la page : cliquez sur un code pour ouvrir le formulaire prérempli.',
       brand_parts_search: 'Rechercher une référence…',
+      brand_parts_search_hint: 'Saisissez au moins 3 caractères, puis cliquez sur un code pour demander un devis.',
+      brand_parts_listino_intro: 'Liste constructeur : recherchez une référence et demandez un devis sans engagement. Aucun prix n’est affiché.',
       brand_parts_count: 'références',
       brand_parts_empty: 'Aucun résultat',
+      brand_parts_type_more: 'Saisissez au moins 3 caractères…',
       brand_parts_case: 'Histoire de réussite',
       brand_parts_quote: 'Demander un devis',
       quote_modal_title: 'Demande sans engagement',
@@ -370,7 +389,7 @@ function enrichMetaWithParts(translations, parts) {
   return translations;
 }
 
-function buildLdJson(brand, slug, tDe, suppliedParts) {
+function buildLdJson(brand, slug, tDe, suppliedParts, listino) {
   const pageUrl = `${BASE}/marche/${slug}.html`;
   const webPage = {
     '@type': 'WebPage',
@@ -384,7 +403,7 @@ function buildLdJson(brand, slug, tDe, suppliedParts) {
     publisher: { '@id': `${BASE}/#organization` },
     primaryImageOfPage: { '@type': 'ImageObject', url: `${BASE}/logo.png` }
   };
-  if (suppliedParts && suppliedParts.length) {
+  if ((suppliedParts && suppliedParts.length) || listino?.count) {
     webPage.dateModified = TODAY;
     webPage.mainEntity = { '@id': pageUrl + '#quotable-parts' };
   }
@@ -424,7 +443,7 @@ function buildLdJson(brand, slug, tDe, suppliedParts) {
       name: `${brand} – quotable part numbers`,
       description: tDe.brand_parts_intro.replace(/<[^>]+>/g, ''),
       numberOfItems: suppliedParts.length,
-      itemListElement: suppliedParts.map((part, i) => ({
+      itemListElement: suppliedParts.slice(0, 50).map((part, i) => ({
         '@type': 'ListItem',
         position: i + 1,
         item: {
@@ -436,12 +455,21 @@ function buildLdJson(brand, slug, tDe, suppliedParts) {
           brand: { '@type': 'Brand', name: brand },
           offers: {
             '@type': 'Offer',
-            url: `${pageUrl}?part=${encodeURIComponent(part.part_number)}#contact`,
+            url: `${pageUrl}?part=${encodeURIComponent(part.part_number)}`,
             availability: 'https://schema.org/InStock',
             seller: { '@id': `${BASE}/#organization` }
           }
         }
       }))
+    });
+  } else if (listino?.count) {
+    graph['@graph'].push({
+      '@type': 'ItemList',
+      '@id': pageUrl + '#quotable-parts',
+      name: `${brand} – searchable manufacturer part codes`,
+      description: (tDe.brand_parts_listino_intro || tDe.brand_parts_intro).replace(/<[^>]+>/g, ''),
+      numberOfItems: listino.count,
+      url: pageUrl
     });
   }
   return JSON.stringify(graph);
@@ -462,12 +490,17 @@ function buildQuoteModalHtml() {
   </div>`;
 }
 
-function buildSuppliedPartsHtml(suppliedParts) {
-  if (!suppliedParts || !suppliedParts.length) return '';
-  const showSearch = suppliedParts.length >= 12;
-  const compact = suppliedParts.every(
-    (part) => !part.description || part.description === part.part_number
-  );
+function buildSuppliedPartsHtml(brandParts) {
+  if (!brandParts) return '';
+  const suppliedParts = brandParts.parts || [];
+  const listino = brandParts.listino;
+  if (!suppliedParts.length && !listino?.count) return '';
+
+  const compact = suppliedParts.length
+    ? suppliedParts.every((part) => !part.description || part.description === part.part_number)
+    : true;
+  const showInlineSearch = suppliedParts.length >= 12 && !listino?.count;
+
   const items = suppliedParts
     .map((part) => {
       const pn = escapeHtml(part.part_number);
@@ -483,7 +516,8 @@ function buildSuppliedPartsHtml(suppliedParts) {
       return `<li class="part-row" data-part-search="${searchKey}"><button type="button" class="part-quote-btn" data-part="${pnAttr}" title="${pnAttr}">${pn}</button>${desc}${caseLink}</li>`;
     })
     .join('\n          ');
-  const searchHtml = showSearch
+
+  const inlineSearchHtml = showInlineSearch
     ? `<div class="parts-toolbar">
         <label class="parts-search-label" for="partsSearchInput"><span class="visually-hidden" data-i18n="brand_parts_search">Teilenummer suchen…</span></label>
         <input type="search" id="partsSearchInput" class="parts-search-input" data-i18n-placeholder="brand_parts_search" placeholder="Teilenummer suchen…" autocomplete="off">
@@ -491,27 +525,50 @@ function buildSuppliedPartsHtml(suppliedParts) {
       </div>
       <p class="parts-empty" id="partsEmpty" hidden data-i18n="brand_parts_empty">Keine Treffer</p>`
     : '';
+
+  const listinoHtml = listino?.count
+    ? `<div class="listino-search" id="listinoSearch" data-listino-src="../${escapeAttr(listino.file)}" data-listino-count="${listino.count}">
+        <p class="parts-intro" data-i18n="brand_parts_listino_intro">Herstellerliste: suchen Sie eine Teilenummer und fordern Sie ein unverbindliches Angebot an. Es werden keine Preise angezeigt.</p>
+        <div class="parts-toolbar">
+          <label class="parts-search-label" for="listinoSearchInput"><span class="visually-hidden" data-i18n="brand_parts_search">Teilenummer suchen…</span></label>
+          <input type="search" id="listinoSearchInput" class="parts-search-input" data-i18n-placeholder="brand_parts_search" placeholder="Teilenummer suchen…" autocomplete="off" enterkeyhint="search">
+          <span class="parts-count" id="listinoCountLabel">${listino.count} <span data-i18n="brand_parts_count">codes</span></span>
+        </div>
+        <p class="parts-hint" data-i18n="brand_parts_search_hint">Mindestens 3 Zeichen eingeben, dann auf einen Code klicken, um anzufragen.</p>
+        <p class="parts-empty" id="listinoEmpty" hidden data-i18n="brand_parts_empty">Keine Treffer</p>
+        <p class="parts-type-more" id="listinoTypeMore" data-i18n="brand_parts_type_more">Bitte mindestens 3 Zeichen eingeben…</p>
+        <ul class="brand-parts-list parts-compact-list" id="listinoResults"></ul>
+      </div>`
+    : '';
+
+  const inlineList = suppliedParts.length
+    ? `${inlineSearchHtml}
+        <ul class="brand-parts-list" id="brandPartsList">
+          ${items}
+        </ul>`
+    : '';
+
   return `
       <section class="brand-supplied-parts${compact ? ' parts-compact' : ''}" id="quotable-parts" aria-labelledby="brand-parts-heading">
         <h2 id="brand-parts-heading" data-i18n="brand_parts_title">Diese Teilenummern anfragen</h2>
-        <p class="parts-intro" data-i18n="brand_parts_intro">Codes aus Angeboten, Lieferungen oder unseren Herstellerlisten.</p>
-        ${searchHtml}
-        <ul class="brand-parts-list" id="brandPartsList">
-          ${items}
-        </ul>
+        <p class="parts-intro" data-i18n="brand_parts_intro">Codes zur Anfrage. Keine Preise auf der Seite.</p>
+        ${inlineList}
+        ${listinoHtml}
       </section>`;
 }
 
-function buildHtml(brand, slug, translations, relatedRows, suppliedParts) {
+function buildHtml(brand, slug, translations, relatedRows, brandParts) {
   const pagePath = `marche/${slug}.html`;
   const pageUrl = `${BASE}/${pagePath}`;
   const tEn = translations.en;
   const d = translations.de;
-  const hasSuppliedParts = !!(suppliedParts && suppliedParts.length);
-  const ld = buildLdJson(brand, slug, d, suppliedParts);
+  const suppliedParts = brandParts?.parts || [];
+  const listino = brandParts?.listino || null;
+  const hasSuppliedParts = suppliedParts.length > 0 || !!(listino && listino.count);
+  const ld = buildLdJson(brand, slug, d, suppliedParts, listino);
   const translationsJson = JSON.stringify(translations);
   const brandJson = JSON.stringify(brand);
-  const suppliedPartsHtml = buildSuppliedPartsHtml(suppliedParts);
+  const suppliedPartsHtml = buildSuppliedPartsHtml(brandParts);
   const quoteModalHtml = hasSuppliedParts ? buildQuoteModalHtml() : '';
   const suppliedPartsExtraCss = hasSuppliedParts ? `
     .part-quote-btn { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.92rem; font-weight: 700; color: #1e3a5f; background: #fff; border: 2px solid #e67e22; border-radius: 8px; padding: 0.35rem 0.65rem; cursor: pointer; }
@@ -520,10 +577,13 @@ function buildHtml(brand, slug, translations, relatedRows, suppliedParts) {
     .parts-search-input { flex: 1; min-width: 180px; padding: 0.55rem 0.75rem; border: 1px solid #c5d4e3; border-radius: 8px; font-size: 0.95rem; }
     .parts-search-input:focus { outline: 2px solid #e67e22; border-color: #e67e22; }
     .parts-count { font-size: 0.85rem; color: #556; white-space: nowrap; }
-    .parts-empty { font-size: 0.9rem; color: #666; margin: 0 0 0.75rem; }
+    .parts-empty, .parts-hint, .parts-type-more { font-size: 0.9rem; color: #666; margin: 0 0 0.75rem; }
+    .listino-search { margin-top: 0.5rem; }
     .brand-parts-list { max-height: min(520px, 60vh); overflow: auto; padding-right: 0.25rem; }
-    .brand-supplied-parts.parts-compact .brand-parts-list { display: flex; flex-direction: row; flex-wrap: wrap; gap: 0.45rem; }
-    .brand-supplied-parts.parts-compact .brand-parts-list li { padding: 0; background: transparent; border: none; border-radius: 0; }
+    .brand-supplied-parts.parts-compact .brand-parts-list,
+    .parts-compact-list { display: flex; flex-direction: row; flex-wrap: wrap; gap: 0.45rem; }
+    .brand-supplied-parts.parts-compact .brand-parts-list li,
+    .parts-compact-list li { padding: 0; background: transparent; border: none; border-radius: 0; }
     .visually-hidden { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
     .quote-modal[hidden] { display: none !important; }
     .quote-modal { position: fixed; inset: 0; z-index: 2000; display: flex; align-items: center; justify-content: center; padding: 1rem; }
@@ -537,7 +597,7 @@ function buildHtml(brand, slug, translations, relatedRows, suppliedParts) {
     .quote-modal-iframe-wrap { border: 1px solid #e0e0e0; border-radius: 8px; overflow: hidden; }
     .quote-modal-iframe-wrap iframe { width: 100%; height: min(900px, 70vh); border: none; display: block; }
     body.quote-modal-open { overflow: hidden; }` : '';
-  const partsJson = JSON.stringify((suppliedParts || []).map((p) => p.part_number));
+  const partsJson = JSON.stringify(suppliedParts.map((p) => p.part_number));
   const relatedLinks = (relatedRows || [])
     .map(({ brand: relatedBrand, slug: relatedSlug }) =>
       `<li><a href="../marche/${relatedSlug}.html">${escapeHtml(relatedBrand)}</a></li>`
@@ -838,6 +898,101 @@ ${hasSuppliedParts ? `    var quoteModal = document.getElementById('quoteModal')
         }
       }
       input.addEventListener('input', applyFilter);
+    }
+    function initListinoSearch() {
+      var box = document.getElementById('listinoSearch');
+      if (!box) return;
+      var src = box.getAttribute('data-listino-src');
+      var input = document.getElementById('listinoSearchInput');
+      var results = document.getElementById('listinoResults');
+      var empty = document.getElementById('listinoEmpty');
+      var typeMore = document.getElementById('listinoTypeMore');
+      var countLabel = document.getElementById('listinoCountLabel');
+      var total = parseInt(box.getAttribute('data-listino-count') || '0', 10) || 0;
+      var codes = null;
+      var loading = false;
+      var MAX_SHOW = 40;
+      function escapeHtmlLocal(s) {
+        return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/\"/g,'&quot;');
+      }
+      function render(matches, q) {
+        results.innerHTML = '';
+        matches.slice(0, MAX_SHOW).forEach(function (code) {
+          var li = document.createElement('li');
+          var btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'part-quote-btn';
+          btn.setAttribute('data-part', code);
+          btn.title = code;
+          btn.textContent = code;
+          btn.addEventListener('click', function () {
+            var langSel = document.getElementById('languageSelect');
+            var lang = langSel ? langSel.value : 'de';
+            openQuoteModal(code, lang);
+          });
+          li.appendChild(btn);
+          results.appendChild(li);
+        });
+        if (empty) empty.hidden = !(q && matches.length === 0);
+        if (typeMore) typeMore.hidden = !!q;
+        if (countLabel) {
+          var unit = countLabel.querySelector('[data-i18n=\"brand_parts_count\"]');
+          var shown = matches.length ? Math.min(matches.length, MAX_SHOW) + (matches.length > MAX_SHOW ? '+' : '') : total;
+          countLabel.childNodes[0].nodeValue = shown + ' ';
+          if (!unit) countLabel.textContent = String(shown);
+        }
+      }
+      function searchNow() {
+        var q = (input.value || '').trim().toLowerCase().replace(/\\s+/g, '');
+        if (q.length < 3) {
+          render([], '');
+          if (typeMore) typeMore.hidden = false;
+          if (empty) empty.hidden = true;
+          return;
+        }
+        if (!codes) return;
+        var matches = [];
+        for (var i = 0; i < codes.length; i++) {
+          var c = codes[i];
+          if (String(c).toLowerCase().replace(/\\s+/g, '').indexOf(q) !== -1) {
+            matches.push(c);
+            if (matches.length >= 200) break;
+          }
+        }
+        render(matches, q);
+      }
+      function ensureLoaded(cb) {
+        if (codes) { cb(); return; }
+        if (loading) return;
+        loading = true;
+        fetch(src).then(function (r) { return r.json(); }).then(function (data) {
+          codes = data.codes || [];
+          total = data.count || codes.length;
+          loading = false;
+          cb();
+        }).catch(function () {
+          loading = false;
+          if (empty) { empty.hidden = false; empty.textContent = 'Catalog load error'; }
+        });
+      }
+      if (input) {
+        input.addEventListener('input', function () {
+          var q = (input.value || '').trim();
+          if (q.length < 3) { searchNow(); return; }
+          ensureLoaded(searchNow);
+        });
+        input.addEventListener('focus', function () { ensureLoaded(function () {}); });
+      }
+      // Deep-link ?part=CODE opens modal even for listino-only pages
+      var urlPart = getUrlPart();
+      if (urlPart) {
+        ensureLoaded(function () {
+          var hit = codes && codes.some(function (c) { return String(c).toLowerCase() === String(urlPart).toLowerCase(); });
+          if (hit || true) {
+            // Always allow quote for typed part on brand page
+          }
+        });
+      }
     }` : ''}
     function changeLanguage(lang) {
       var t = translations[lang] || translations.de;
@@ -881,6 +1036,7 @@ ${hasSuppliedParts ? `      if (quoteModal && !quoteModal.hasAttribute('hidden')
       changeLanguage(lang);
 ${hasSuppliedParts ? `      initPartQuoteButtons();
       initPartsSearch();
+      initListinoSearch();
       if (initialPart) {
         setTimeout(function () { openQuoteModal(initialPart, lang); }, 200);
       }` : ''}
@@ -963,13 +1119,34 @@ ${partsBlock}${partCodesBlock}${casesBlock}</sitemapindex>
   fs.writeFileSync(outPath, xml, 'utf8');
 }
 
+function parseOnlySlugs(argv) {
+  const only = [];
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--only' && argv[i + 1]) {
+      only.push(...String(argv[++i]).split(',').map((s) => s.trim()).filter(Boolean));
+    } else if (a.startsWith('--only=')) {
+      only.push(...a.slice('--only='.length).split(',').map((s) => s.trim()).filter(Boolean));
+    }
+  }
+  return [...new Set(only.map((s) => s.toLowerCase()))];
+}
+
 function main() {
+  const onlySlugs = parseOnlySlugs(process.argv);
   const brands = readBrandsFromIndex();
   const rows = assignUniqueSlugs(brands);
   const partsBySlug = loadPartsBySlug();
+  const targetRows = onlySlugs.length
+    ? rows.filter((r) => onlySlugs.includes(r.slug))
+    : rows;
+
+  if (onlySlugs.length && !targetRows.length) {
+    throw new Error(`No matching brand slugs for --only=${onlySlugs.join(',')}`);
+  }
 
   fs.mkdirSync(MARCHE_DIR, { recursive: true });
-  if (fs.existsSync(MARCHE_DIR)) {
+  if (!onlySlugs.length && fs.existsSync(MARCHE_DIR)) {
     for (const name of fs.readdirSync(MARCHE_DIR)) {
       if (name.endsWith('.html')) {
         fs.unlinkSync(path.join(MARCHE_DIR, name));
@@ -980,6 +1157,8 @@ function main() {
   let n = 0;
   for (let i = 0; i < rows.length; i++) {
     const { brand, slug } = rows[i];
+    if (onlySlugs.length && !onlySlugs.includes(slug)) continue;
+
     const relatedRows = [];
     for (let step = 1; step <= 3; step++) {
       const left = rows[i - step];
@@ -989,27 +1168,46 @@ function main() {
     }
     const translations = buildTranslations(brand);
     mergeTopBrandContent(translations, slug);
-    const suppliedParts = partsBySlug.get(slug) || [];
-    if (suppliedParts.length) enrichMetaWithParts(translations, suppliedParts);
-    const html = buildHtml(brand, slug, translations, relatedRows, suppliedParts);
+    const brandParts = partsBySlug.get(slug) || null;
+    if (brandParts?.parts?.length) enrichMetaWithParts(translations, brandParts.parts);
+    else if (brandParts?.listino?.count) {
+      for (const lang of ['de', 'en', 'it', 'es', 'fr']) {
+        const base = String(translations[lang].meta_description || '');
+        const note = {
+          de: ` ${brandParts.listino.count}+ Teilenummern suchbar — Anfrage ohne Preise.`,
+          en: ` ${brandParts.listino.count}+ searchable part numbers — request a quote, no prices shown.`,
+          it: ` ${brandParts.listino.count}+ codici cercabili — richiesta senza prezzi in pagina.`,
+          es: ` ${brandParts.listino.count}+ códigos buscables — solicitud sin precios en página.`,
+          fr: ` ${brandParts.listino.count}+ références recherchables — demande sans prix affichés.`
+        }[lang];
+        let meta = base + note;
+        if (meta.length > MAX_META_LEN) meta = `${meta.slice(0, MAX_META_LEN - 1).trim()}…`;
+        translations[lang].meta_description = meta;
+      }
+    }
+    const html = buildHtml(brand, slug, translations, relatedRows, brandParts);
     fs.writeFileSync(path.join(MARCHE_DIR, slug + '.html'), html, 'utf8');
     n++;
-    if (n % 500 === 0) console.log('Written', n, '/', rows.length);
+    if (n % 500 === 0) console.log('Written', n, '/', targetRows.length);
   }
 
-  writeSitemapBrands(rows, partsBySlug);
-  writeSitemapIndex();
-  fs.writeFileSync(
-    path.join(ROOT, 'brand-slugs.json'),
-    JSON.stringify(rows.reduce((acc, { brand, slug }) => {
-      acc[brand] = slug;
-      return acc;
-    }, {}), null, 0),
-    'utf8'
-  );
+  if (!onlySlugs.length) {
+    writeSitemapBrands(rows, partsBySlug);
+    writeSitemapIndex();
+    fs.writeFileSync(
+      path.join(ROOT, 'brand-slugs.json'),
+      JSON.stringify(rows.reduce((acc, { brand, slug }) => {
+        acc[brand] = slug;
+        return acc;
+      }, {}), null, 0),
+      'utf8'
+    );
+    console.log('sitemap-brands.xml, sitemap-index.xml and brand-slugs.json updated.');
+  } else {
+    console.log('Partial rebuild (--only): skipped full sitemap-brands rewrite.');
+  }
 
-  console.log('Brand pages:', n, 'in', path.relative(ROOT, MARCHE_DIR));
-  console.log('sitemap-brands.xml, sitemap-index.xml and brand-slugs.json updated.');
+  console.log('Brand pages:', n, onlySlugs.length ? `(only: ${onlySlugs.join(',')})` : '', 'in', path.relative(ROOT, MARCHE_DIR));
 }
 
 main();

--- a/import-listino.js
+++ b/import-listino.js
@@ -20,6 +20,9 @@ const path = require('path');
 
 const ROOT = __dirname;
 const LISTINI_DIR = path.join(ROOT, 'listini');
+const LISTINI_DATA_DIR = path.join(ROOT, 'listini-data');
+/** Above this count, codes go to listini-data/{slug}.json instead of inline HTML. */
+const INLINE_LISTINO_MAX = 200;
 
 const CODE_HEADERS = new Set([
   'part_number', 'partnumber', 'part', 'code', 'codice', 'codicearticolo',
@@ -36,7 +39,7 @@ const DESC_HEADERS = new Set([
 const PRICE_HEADERS = new Set([
   'price', 'preis', 'prezzo', 'list_price', 'listino', 'netto', 'net', 'brutto',
   'eur', 'usd', 'chf', 'gbp', 'amount', 'betrag', 'costo', 'cost', 'vk', 'ek',
-  'rabatt', 'discount', 'mwst', 'vat', 'iva'
+  'rabatt', 'discount', 'mwst', 'vat', 'iva', 'sales_price', 'verkaufspreis'
 ]);
 
 function isPriceHeader(header) {
@@ -210,7 +213,8 @@ function loadListiniParts() {
       continue;
     }
     if (!bySlug.has(slug)) bySlug.set(slug, []);
-    bySlug.get(slug).push(...parts);
+    const bucket = bySlug.get(slug);
+    for (let i = 0; i < parts.length; i++) bucket.push(parts[i]);
     console.log(`listini/${file}: ${parts.length} code(s) → ${slug}`);
   }
 
@@ -227,17 +231,47 @@ function loadListiniParts() {
         }
       }
     }
-    bySlug.set(slug, [...map.values()]);
+    bySlug.set(slug, Array.from(map.values()));
   }
 
   return bySlug;
 }
 
+/**
+ * Write compact JSON catalog for large listini (codes only, no prices).
+ * @returns {{ file: string, count: number, preview: string[] }}
+ */
+function writeListinoDataFile(brandSlug, brandName, parts) {
+  if (!fs.existsSync(LISTINI_DATA_DIR)) fs.mkdirSync(LISTINI_DATA_DIR, { recursive: true });
+  const codes = parts
+    .map((p) => String(p.part_number || '').trim())
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+  const rel = `listini-data/${brandSlug}.json`;
+  const payload = {
+    brand: brandName,
+    brand_slug: brandSlug,
+    count: codes.length,
+    generated: new Date().toISOString().slice(0, 10),
+    note: 'Part codes only — no prices. Click a code on the brand page to request a quote.',
+    codes
+  };
+  fs.writeFileSync(path.join(ROOT, rel), `${JSON.stringify(payload)}\n`, 'utf8');
+  return {
+    file: rel,
+    count: codes.length,
+    preview: codes.slice(0, 8)
+  };
+}
+
 module.exports = {
   loadListiniParts,
+  writeListinoDataFile,
   parseTxt,
   parseCsv,
   parseXlsx,
   isLikelyPartCode,
-  LISTINI_DIR
+  LISTINI_DIR,
+  LISTINI_DATA_DIR,
+  INLINE_LISTINO_MAX
 };

--- a/listini/README.md
+++ b/listini/README.md
@@ -43,10 +43,26 @@ Senza intestazione: **prima colonna = codice**. Colonne prezzo ignorate.
 
 Prima foglio del workbook. Basta la colonna codice; descrizione e prezzi possono esserci o no.
 
-## Build
+## Listini grandi (es. ABB 100k+ codici)
+
+Se il file ha più di 200 codici:
+- i codici vanno in `listini-data/{slug}.json` (solo codici, **senza prezzi**)
+- sulla pagina marca compare una **ricerca** (min. 3 caratteri)
+- click sul risultato → form di richiesta precompilato
+- il `.xlsx` resta locale (gitignore), in git va solo il JSON
+
+## Build (step-by-step)
 
 ```bash
-npm run build:brand-parts-pages
+# 1) Metti il file listino (es. listini/abb.xlsx) — i prezzi non vengono pubblicati
+# 2) Rigenera catalogo JSON
+npm run build:brand-parts
+
+# 3) Rigenera SOLO la pagina marca interessata (consigliato per listini grandi)
+node generate-brand-pages.js --only=abb
+
+# Oppure tutte le pagine (lento, ~12k file):
+npm run build:brand-pages
 ```
 
 I codici già presenti in ordini/preventivi **non vengono duplicati**.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "build:marche": "node extract-brands.js",
     "build:brand-parts": "node build-brand-parts.js",
     "build:brand-pages": "node generate-brand-pages.js",
+    "build:brand-pages:only": "node generate-brand-pages.js --only",
     "build:brand-parts-pages": "node build-brand-parts.js && node generate-brand-pages.js",
     "import:listino": "node -e \"require('./import-listino').loadListiniParts()\"",
     "build:brands": "node extract-brands.js && node generate-brand-pages.js",

--- a/verify-build.js
+++ b/verify-build.js
@@ -57,7 +57,9 @@ const sbpPath = path.join(__dirname, 'sitemap-brand-parts.xml');
 if (!fs.existsSync(sbpPath)) throw new Error('sitemap-brand-parts.xml missing — run npm run build:brand-parts');
 const sbp = fs.readFileSync(sbpPath, 'utf8');
 const partsDataEarly = JSON.parse(fs.readFileSync(path.join(__dirname, 'brand-order-parts.json'), 'utf8'));
-const partsBrandCount = (partsDataEarly.brands || []).filter((b) => b.brand_slug && b.parts?.length).length;
+const partsBrandCount = (partsDataEarly.brands || []).filter(
+  (b) => b.brand_slug && ((b.parts && b.parts.length) || b.listino?.count)
+).length;
 const partsUrlCount = (sbp.match(/<loc>/g) || []).length;
 if (partsUrlCount !== partsBrandCount) {
   throw new Error(`sitemap-brand-parts.xml <loc> count ${partsUrlCount} !== brands with parts ${partsBrandCount}`);
@@ -66,6 +68,7 @@ if (partsUrlCount !== partsBrandCount) {
 const spcPath = path.join(__dirname, 'sitemap-part-codes.xml');
 if (!fs.existsSync(spcPath)) throw new Error('sitemap-part-codes.xml missing — run npm run build:brand-parts');
 const spc = fs.readFileSync(spcPath, 'utf8');
+// Large listini live in listini-data/*.json and use on-page search — not one sitemap URL per code.
 const totalPartRefs = (partsDataEarly.brands || []).reduce((sum, row) => sum + (row.parts?.length || 0), 0);
 const partCodeUrlCount = (spc.match(/<loc>/g) || []).length;
 if (partCodeUrlCount !== totalPartRefs) {
@@ -212,15 +215,19 @@ for (const f of toCheck) {
 }
 
 const partsData = JSON.parse(fs.readFileSync(path.join(__dirname, 'brand-order-parts.json'), 'utf8'));
-const partsSlugs = (partsData.brands || []).filter((b) => b.brand_slug && b.parts?.length).map((b) => b.brand_slug);
 for (const row of partsData.brands || []) {
-  if (!row.brand_slug || !row.parts?.length) continue;
+  if (!row.brand_slug) continue;
+  if (!row.parts?.length && !row.listino?.count) continue;
   if (!llmsTxt.includes(`marche/${row.brand_slug}.html`)) {
     throw new Error(`llms.txt does not mention brand page marche/${row.brand_slug}.html`);
   }
 }
-for (const slug of partsSlugs) {
-  const f = slug + '.html';
+for (const row of partsData.brands || []) {
+  if (!row.brand_slug) continue;
+  const hasInline = !!(row.parts && row.parts.length);
+  const hasListino = !!(row.listino && row.listino.count);
+  if (!hasInline && !hasListino) continue;
+  const f = row.brand_slug + '.html';
   const content = fs.readFileSync(path.join(marcheDir, f), 'utf8');
   if (!content.includes('brand-supplied-parts')) {
     throw new Error(`Missing supplied-parts section in marche/${f}`);
@@ -228,8 +235,20 @@ for (const slug of partsSlugs) {
   if (!content.includes('id="quotable-parts"')) {
     throw new Error(`Missing quotable-parts section id in marche/${f}`);
   }
-  if (!content.includes('id="quoteModal"') || !content.includes('part-quote-btn')) {
-    throw new Error(`Missing quote modal / part buttons in marche/${f}`);
+  if (!content.includes('id="quoteModal"')) {
+    throw new Error(`Missing quote modal in marche/${f}`);
+  }
+  if (hasInline && !content.includes('part-quote-btn')) {
+    throw new Error(`Missing quote part buttons in marche/${f}`);
+  }
+  if (hasListino) {
+    if (!content.includes('id="listinoSearch"') || !content.includes(row.listino.file)) {
+      throw new Error(`Missing listino search UI in marche/${f}`);
+    }
+    const dataFile = path.join(__dirname, row.listino.file);
+    if (!fs.existsSync(dataFile)) {
+      throw new Error(`Missing listino data file ${row.listino.file}`);
+    }
   }
   if (!content.includes('custom_part_numbers=')) {
     throw new Error(`Missing ERP part prefill param in marche/${f}`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Step 1/2 — Infrastruttura listini grandi

Prepara il sito a gestire listini con decine/centinaia di migliaia di codici **senza** riscrivere tutte le ~12.000 pagine marca.

### Cosa include
- Import listini → se >200 codici: `listini-data/{slug}.json` (solo codici, **nessun prezzo**)
- UI ricerca sulla pagina marca (min. 3 caratteri → click → form ERP)
- `node generate-brand-pages.js --only=abb` per rebuild mirato
- `.gitignore` per `listini/*.xlsx`
- verify aggiornato per brand con `listino`

### Cosa NON include
- Dati ABB / `listini-data/abb.json` → **Step 2**

Sostituisce il PR #22 monolitico (~12k file).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5667143c-3775-4cc2-ac52-51c405dcb832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5667143c-3775-4cc2-ac52-51c405dcb832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

