### PR TITLE
Sitemap principale sempre aggiornato (index + lastmod, senza perdere i listini)

### DIFF
--- a/build-brand-parts.js
+++ b/build-brand-parts.js
@@ -458,17 +458,49 @@ ${body}</urlset>
   return { files, urlCount };
 }
 
-function writeSitemapIndex(listinoSitemapFiles = []) {
+/** Discover listino shard sitemap files currently on disk. */
+function listListinoSitemapFiles() {
+  return fs
+    .readdirSync(ROOT)
+    .filter((name) => /^sitemap-parts-[a-z0-9-]+(?:-\d+)?\.xml$/i.test(name))
+    .sort();
+}
+
+/**
+ * Refresh lastmod dates in the root sitemap.xml (core site URLs).
+ * Keeps Google Search Console / crawlers aware the main sitemap changed.
+ */
+function touchMainSitemap() {
+  const p = path.join(ROOT, 'sitemap.xml');
+  if (!fs.existsSync(p)) return;
+  let xml = fs.readFileSync(p, 'utf8');
+  xml = xml.replace(/<lastmod>[^<]+<\/lastmod>/g, `<lastmod>${TODAY}</lastmod>`);
+  fs.writeFileSync(p, xml, 'utf8');
+}
+
+/**
+ * Always rewrite sitemap-index.xml with every known sitemap, including listino shards.
+ * Call this from brand-parts, brand-pages, and cases builds so the index never drifts.
+ * @param {string[]} [listinoSitemapFiles]
+ */
+function writeSitemapIndex(listinoSitemapFiles) {
+  const shards = Array.isArray(listinoSitemapFiles) && listinoSitemapFiles.length
+    ? [...listinoSitemapFiles].sort()
+    : listListinoSitemapFiles();
+
   const entries = [
     'sitemap.xml',
     'sitemap-brands.xml',
     'sitemap-brand-parts.xml',
     'sitemap-part-codes.xml',
-    ...listinoSitemapFiles,
+    ...shards,
     'sitemap-cases.xml'
-  ];
+  ].filter((file, idx, arr) => arr.indexOf(file) === idx);
+
   let body = '';
   for (const file of entries) {
+    // Skip optional files that are not present yet (e.g. first bootstrap).
+    if (file !== 'sitemap.xml' && !fs.existsSync(path.join(ROOT, file))) continue;
     body += '  <sitemap>\n';
     body += `    <loc>${BASE}/${file}</loc>\n`;
     body += `    <lastmod>${TODAY}</lastmod>\n`;
@@ -482,18 +514,22 @@ layout: none
 ${body}</sitemapindex>
 `;
   fs.writeFileSync(path.join(ROOT, 'sitemap-index.xml'), xml, 'utf8');
+  touchMainSitemap();
 }
 
-function updateRobotsTxt(listinoSitemapFiles = []) {
+function updateRobotsTxt(listinoSitemapFiles) {
   const robotsPath = path.join(ROOT, 'robots.txt');
   let content = fs.readFileSync(robotsPath, 'utf8');
+  const shards = Array.isArray(listinoSitemapFiles) && listinoSitemapFiles.length
+    ? [...listinoSitemapFiles].sort()
+    : listListinoSitemapFiles();
   const sitemapBlock = [
     'Sitemap: https://abcspareparts.eu/sitemap-index.xml',
     'Sitemap: https://abcspareparts.eu/sitemap.xml',
     'Sitemap: https://abcspareparts.eu/sitemap-brands.xml',
     'Sitemap: https://abcspareparts.eu/sitemap-brand-parts.xml',
     'Sitemap: https://abcspareparts.eu/sitemap-part-codes.xml',
-    ...listinoSitemapFiles.map((f) => `Sitemap: https://abcspareparts.eu/${f}`),
+    ...shards.map((f) => `Sitemap: https://abcspareparts.eu/${f}`),
     'Sitemap: https://abcspareparts.eu/sitemap-cases.xml'
   ].join('\n');
 
@@ -594,7 +630,7 @@ function main() {
   console.log('sitemap-brand-parts.xml:', output.brands.length, 'URLs');
   console.log('sitemap-part-codes.xml:', partUrlCount, 'URLs');
   console.log('listino sitemap shards:', listinoSitemaps.files.length, 'files,', listinoSitemaps.urlCount, 'URLs');
-  console.log('sitemap-index.xml + robots.txt + llms.txt updated');
+  console.log('sitemap-index.xml + sitemap.xml + robots.txt + llms.txt updated');
   for (const row of output.brands) {
     const extra = row.listino?.count ? ` + listino ${row.listino.count}` : '';
     console.log(`  ${row.brand} (${row.brand_slug}): ${(row.parts || []).length}${extra}`);
@@ -612,6 +648,8 @@ module.exports = {
   writeSitemapBrandParts,
   writeSitemapPartCodes,
   writeSitemapListinoShards,
+  listListinoSitemapFiles,
+  touchMainSitemap,
   writeSitemapIndex,
   updateRobotsTxt,
   updateLlmsTxt,

--- a/generate-brand-pages.js
+++ b/generate-brand-pages.js
@@ -1178,44 +1178,10 @@ ${body}</urlset>
 }
 
 function writeSitemapIndex() {
-  const outPath = path.join(ROOT, 'sitemap-index.xml');
-  const casesBlock = fs.existsSync(path.join(ROOT, 'sitemap-cases.xml'))
-    ? `  <sitemap>
-    <loc>${BASE}/sitemap-cases.xml</loc>
-    <lastmod>${TODAY}</lastmod>
-  </sitemap>
-`
-    : '';
-  const partsBlock = fs.existsSync(path.join(ROOT, 'sitemap-brand-parts.xml'))
-    ? `  <sitemap>
-    <loc>${BASE}/sitemap-brand-parts.xml</loc>
-    <lastmod>${TODAY}</lastmod>
-  </sitemap>
-`
-    : '';
-  const partCodesBlock = fs.existsSync(path.join(ROOT, 'sitemap-part-codes.xml'))
-    ? `  <sitemap>
-    <loc>${BASE}/sitemap-part-codes.xml</loc>
-    <lastmod>${TODAY}</lastmod>
-  </sitemap>
-`
-    : '';
-  const xml = `---
-layout: none
----
-<?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <sitemap>
-    <loc>${BASE}/sitemap.xml</loc>
-    <lastmod>${TODAY}</lastmod>
-  </sitemap>
-  <sitemap>
-    <loc>${BASE}/sitemap-brands.xml</loc>
-    <lastmod>${TODAY}</lastmod>
-  </sitemap>
-${partsBlock}${partCodesBlock}${casesBlock}</sitemapindex>
-`;
-  fs.writeFileSync(outPath, xml, 'utf8');
+  // Keep listino shard sitemaps in the index (do not overwrite with a partial list).
+  const { writeSitemapIndex: writeFullSitemapIndex, updateRobotsTxt } = require('./build-brand-parts.js');
+  writeFullSitemapIndex();
+  updateRobotsTxt();
 }
 
 function parseOnlySlugs(argv) {

--- a/generate-case-pages.js
+++ b/generate-case-pages.js
@@ -784,24 +784,11 @@ ${body}</urlset>
 }
 
 function updateSitemapIndex() {
-  const p = path.join(ROOT, 'sitemap-index.xml');
-  let xml = fs.readFileSync(p, 'utf8');
-  if (!xml.includes('/sitemap-cases.xml')) {
-    xml = xml.replace(
-      '</sitemapindex>',
-      `  <sitemap>
-    <loc>${BASE}/sitemap-cases.xml</loc>
-    <lastmod>${TODAY}</lastmod>
-  </sitemap>
-</sitemapindex>`
-    );
-  } else {
-    xml = xml.replace(
-      /(<loc>https:\/\/abcspareparts\.eu\/sitemap-cases\.xml<\/loc>\s*<lastmod>)[^<]+(<\/lastmod>)/,
-      `$1${TODAY}$2`
-    );
-  }
-  fs.writeFileSync(p, xml, 'utf8');
+  // Full rewrite so sitemap-index.xml always lists every sitemap (including listino shards)
+  // and sitemap.xml lastmod stays fresh.
+  const { writeSitemapIndex, updateRobotsTxt } = require('./build-brand-parts.js');
+  writeSitemapIndex();
+  updateRobotsTxt();
 }
 
 function updateLlmsTxt(cases) {

--- a/listini/README.md
+++ b/listini/README.md
@@ -53,6 +53,7 @@ Se il file ha più di 200 codici:
 - sulla pagina marca: **ricerca** (min. 3 caratteri), **esempi di prefisso** cliccabili, e una **piccola lista campione** in HTML (per SEO/AI e per far capire come cercare)
 - click sul risultato o sul campione → form di richiesta precompilato
 - il `.xlsx` resta locale (gitignore); in git vanno il JSON e la pagina marca
+- `npm run build:brand-parts` aggiorna **sempre** anche `sitemap-index.xml`, `sitemap.xml` (lastmod), `robots.txt` e gli shard `sitemap-parts-*.xml`
 
 La rebuild senza il file Excel riusa `listini-data/{slug}.json` già pubblicato.
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -14,7 +14,7 @@ layout: none
     <xhtml:link rel="alternate" hreflang="es" href="https://abcspareparts.eu/?lang=es"/>
     <xhtml:link rel="alternate" hreflang="fr" href="https://abcspareparts.eu/?lang=fr"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://abcspareparts.eu/"/>
-    <lastmod>2026-04-21</lastmod>
+    <lastmod>2026-07-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -28,7 +28,7 @@ layout: none
     <xhtml:link rel="alternate" hreflang="es" href="https://abcspareparts.eu/marche.html?lang=es"/>
     <xhtml:link rel="alternate" hreflang="fr" href="https://abcspareparts.eu/marche.html?lang=fr"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://abcspareparts.eu/marche.html"/>
-    <lastmod>2026-07-07</lastmod>
+    <lastmod>2026-07-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -45,7 +45,7 @@ layout: none
     <xhtml:link rel="alternate" hreflang="es" href="https://abcspareparts.eu/casi.html?lang=es"/>
     <xhtml:link rel="alternate" hreflang="fr" href="https://abcspareparts.eu/casi.html?lang=fr"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://abcspareparts.eu/casi.html"/>
-    <lastmod>2026-06-23</lastmod>
+    <lastmod>2026-07-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.75</priority>
   </url>
@@ -55,7 +55,7 @@ layout: none
   <!-- Impressum -->
   <url>
     <loc>https://abcspareparts.eu/impressum.html</loc>
-    <lastmod>2026-03-01</lastmod>
+    <lastmod>2026-07-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -63,7 +63,7 @@ layout: none
   <!-- Datenschutz -->
   <url>
     <loc>https://abcspareparts.eu/datenschutz.html</loc>
-    <lastmod>2026-03-01</lastmod>
+    <lastmod>2026-07-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -71,7 +71,7 @@ layout: none
   <!-- AGB -->
   <url>
     <loc>https://abcspareparts.eu/agb.html</loc>
-    <lastmod>2026-03-01</lastmod>
+    <lastmod>2026-07-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -79,7 +79,7 @@ layout: none
   <!-- Versand -->
   <url>
     <loc>https://abcspareparts.eu/versand.html</loc>
-    <lastmod>2026-03-01</lastmod>
+    <lastmod>2026-07-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>

--- a/verify-build.js
+++ b/verify-build.js
@@ -130,6 +130,21 @@ if (listinoBrands.length && listinoShardUrlTotal !== expectedListinoUrls) {
   );
 }
 
+// Root sitemap.xml must stay fresh whenever the index is maintained (Search Console).
+const mainSitemapPath = path.join(__dirname, 'sitemap.xml');
+if (!fs.existsSync(mainSitemapPath)) throw new Error('sitemap.xml missing');
+const mainSitemap = fs.readFileSync(mainSitemapPath, 'utf8');
+const mainLastmods = [...mainSitemap.matchAll(/<lastmod>([^<]+)<\/lastmod>/g)].map((m) => m[1]);
+if (!mainLastmods.length) throw new Error('sitemap.xml has no <lastmod> entries');
+const today = new Date().toISOString().slice(0, 10);
+if (mainLastmods.some((d) => d !== today)) {
+  throw new Error(`sitemap.xml lastmod must be ${today} (got ${[...new Set(mainLastmods)].join(', ')}) — rebuild brand-parts/brand-pages/casi`);
+}
+const indexLastmods = [...si.matchAll(/<lastmod>([^<]+)<\/lastmod>/g)].map((m) => m[1]);
+if (indexLastmods.some((d) => d !== today)) {
+  throw new Error(`sitemap-index.xml lastmod must be ${today} — rebuild brand-parts/brand-pages/casi`);
+}
+
 const casesPath = path.join(__dirname, 'supply-cases.json');
 if (!fs.existsSync(casesPath)) throw new Error('supply-cases.json missing');
 const casesData = JSON.parse(fs.readFileSync(casesPath, 'utf8'));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Il **sitemap principale** (`sitemap-index.xml` + `sitemap.xml`) viene sempre aggiornato insieme ai listini, e non può più perdere gli shard.

## Problema
`generate-brand-pages.js` riscriveva `sitemap-index.xml` **senza** i file `sitemap-parts-*.xml` (ABB, Siemens, Schneider Electric, …), quindi un rebuild pagine marca poteva far sparire i listini dall’indice usato da Google Search Console.

## Fix
- Writer condiviso in `build-brand-parts.js`: scopre gli shard su disco, riscrive `sitemap-index.xml`, aggiorna `robots.txt`, e rinfresca i `<lastmod>` di `sitemap.xml`
- Usato anche da `generate-brand-pages.js` e `generate-case-pages.js`
- `verify-build.js` controlla che `sitemap.xml` e `sitemap-index.xml` abbiano `lastmod` odierno

## Verify
`npm run verify` → OK
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5667143c-3775-4cc2-ac52-51c405dcb832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5667143c-3775-4cc2-ac52-51c405dcb832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

