### PR TITLE
Jekyll: pubblica tutti i sitemap listino (incluso Telemecanique)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,21 +3,36 @@ title: ABCspareparts
 description: MRO industrial spare parts distributor
 url: "https://abcspareparts.eu"
 
-# Include sitemap.xml as proper XML
+# Root static files that must always publish.
+# build-brand-parts.js rewrites the listino-sitemaps markers when listini change.
 include:
+  - robots.txt
+  - llms.txt
+  - listini-data
   - sitemap.xml
-  - sitemap-brands.xml
-  - sitemap-cases.xml
   - sitemap-index.xml
+  - sitemap-brands.xml
+  - sitemap-brand-parts.xml
+  - sitemap-part-codes.xml
+  - sitemap-cases.xml
+  # BEGIN listino-sitemaps
+  - sitemap-parts-abb-1.xml
+  - sitemap-parts-abb-2.xml
+  - sitemap-parts-abb-3.xml
+  - sitemap-parts-ifm.xml
+  - sitemap-parts-schneider-electric-1.xml
+  - sitemap-parts-schneider-electric-2.xml
+  - sitemap-parts-schneider.xml
+  - sitemap-parts-siemens-1.xml
+  - sitemap-parts-siemens-2.xml
+  - sitemap-parts-siemens-3.xml
+  - sitemap-parts-telemecanique.xml
+  # END listino-sitemaps
 
-# Disable Jekyll processing on XML files
+# Serve sitemap XML without Liquid wrapping (layout: none strips front matter).
 defaults:
   - scope:
       path: "sitemap.xml"
-    values:
-      layout: none
-  - scope:
-      path: "sitemap-brands.xml"
     values:
       layout: none
   - scope:
@@ -25,6 +40,64 @@ defaults:
     values:
       layout: none
   - scope:
+      path: "sitemap-brands.xml"
+    values:
+      layout: none
+  - scope:
+      path: "sitemap-brand-parts.xml"
+    values:
+      layout: none
+  - scope:
+      path: "sitemap-part-codes.xml"
+    values:
+      layout: none
+  - scope:
       path: "sitemap-cases.xml"
     values:
       layout: none
+  # BEGIN listino-sitemap-defaults
+  - scope:
+      path: "sitemap-parts-abb-1.xml"
+    values:
+      layout: none
+  - scope:
+      path: "sitemap-parts-abb-2.xml"
+    values:
+      layout: none
+  - scope:
+      path: "sitemap-parts-abb-3.xml"
+    values:
+      layout: none
+  - scope:
+      path: "sitemap-parts-ifm.xml"
+    values:
+      layout: none
+  - scope:
+      path: "sitemap-parts-schneider-electric-1.xml"
+    values:
+      layout: none
+  - scope:
+      path: "sitemap-parts-schneider-electric-2.xml"
+    values:
+      layout: none
+  - scope:
+      path: "sitemap-parts-schneider.xml"
+    values:
+      layout: none
+  - scope:
+      path: "sitemap-parts-siemens-1.xml"
+    values:
+      layout: none
+  - scope:
+      path: "sitemap-parts-siemens-2.xml"
+    values:
+      layout: none
+  - scope:
+      path: "sitemap-parts-siemens-3.xml"
+    values:
+      layout: none
+  - scope:
+      path: "sitemap-parts-telemecanique.xml"
+    values:
+      layout: none
+  # END listino-sitemap-defaults

--- a/build-brand-parts.js
+++ b/build-brand-parts.js
@@ -515,6 +515,51 @@ ${body}</sitemapindex>
 `;
   fs.writeFileSync(path.join(ROOT, 'sitemap-index.xml'), xml, 'utf8');
   touchMainSitemap();
+  updateJekyllConfig(shards);
+}
+
+/**
+ * Keep _config.yml include + defaults in sync with listino sitemap shards
+ * so GitHub Pages / Jekyll always publishes them.
+ */
+function updateJekyllConfig(listinoSitemapFiles) {
+  const configPath = path.join(ROOT, '_config.yml');
+  if (!fs.existsSync(configPath)) return;
+  const shards = Array.isArray(listinoSitemapFiles) && listinoSitemapFiles.length
+    ? [...listinoSitemapFiles].sort()
+    : listListinoSitemapFiles();
+
+  const includeBlock = [
+    '  # BEGIN listino-sitemaps',
+    ...shards.map((f) => `  - ${f}`),
+    '  # END listino-sitemaps'
+  ].join('\n');
+
+  const defaultsBlock = [
+    '  # BEGIN listino-sitemap-defaults',
+    ...shards.map(
+      (f) => `  - scope:
+      path: "${f}"
+    values:
+      layout: none`
+    ),
+    '  # END listino-sitemap-defaults'
+  ].join('\n');
+
+  let content = fs.readFileSync(configPath, 'utf8');
+  if (!/# BEGIN listino-sitemaps/.test(content) || !/# BEGIN listino-sitemap-defaults/.test(content)) {
+    console.warn('_config.yml missing listino sitemap markers — skip auto-update');
+    return;
+  }
+  content = content.replace(
+    /  # BEGIN listino-sitemaps[\s\S]*?  # END listino-sitemaps/,
+    includeBlock
+  );
+  content = content.replace(
+    /  # BEGIN listino-sitemap-defaults[\s\S]*?  # END listino-sitemap-defaults/,
+    defaultsBlock
+  );
+  fs.writeFileSync(configPath, content.endsWith('\n') ? content : `${content}\n`, 'utf8');
 }
 
 function updateRobotsTxt(listinoSitemapFiles) {
@@ -650,6 +695,7 @@ module.exports = {
   writeSitemapListinoShards,
   listListinoSitemapFiles,
   touchMainSitemap,
+  updateJekyllConfig,
   writeSitemapIndex,
   updateRobotsTxt,
   updateLlmsTxt,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Telemecanique era già online (PR #34). Questo PR rafforza la pubblicazione dei sitemap su GitHub Pages.

## Fix
- `_config.yml` include/defaults per **tutti** gli shard `sitemap-parts-*.xml` (ABB, Siemens, Schneider Electric, IFM, Telemecanique, SCHNEIDER)
- `build-brand-parts.js` aggiorna automaticamente i marker in `_config.yml` a ogni nuovo listino

Evita che Jekyll salti o dia errori intermittenti sui sitemap listino.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5667143c-3775-4cc2-ac52-51c405dcb832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5667143c-3775-4cc2-ac52-51c405dcb832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

